### PR TITLE
Auto-increment build number

### DIFF
--- a/KICKOFF_PROJECT_NAME.xcodeproj/project.pbxproj
+++ b/KICKOFF_PROJECT_NAME.xcodeproj/project.pbxproj
@@ -252,6 +252,7 @@
 				73779B6D7D908FA144CBA9A4 /* Frameworks */,
 				417DB48342C297D9F50241D4 /* Resources */,
 				F83205341D83695500047B79 /* Embed Carthage Dependencies */,
+				F89879141D873936008BF296 /* Increment build number */,
 			);
 			buildRules = (
 			);
@@ -356,6 +357,7 @@
 			shellScript = "/usr/local/bin/carthage copy-frameworks";
 		};
 		F89879131D87375F008BF296 /* Validate Carthage dependencies */ = {
+		F89879141D873936008BF296 /* Increment build number */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -363,11 +365,13 @@
 			inputPaths = (
 			);
 			name = "Validate Carthage dependencies";
+			name = "Increment build number";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "if ! cmp -s \"$SRCROOT/Cartfile.resolved\" \"$SRCROOT/Carthage/Cartfile.resolved\"; then\n    >&2 echo \"error: Your dependencies are out of date. Run bin/bootstrap to update.\"\n    exit 1\nfi";
+			shellScript = "git=$(sh /etc/profile; which git)\nnumber_of_commits=$(\"$git\" rev-list master --count)\ntarget_plist=\"$TARGET_BUILD_DIR/$INFOPLIST_PATH\"\ndsym_plist=\"$DWARF_DSYM_FOLDER_PATH/$DWARF_DSYM_FILE_NAME/Contents/Info.plist\"\n\nfor plist in \"$target_plist\" \"$dsym_plist\"; do\n    if [ -f \"$plist\" ]; then\n        /usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $number_of_commits\" \"$plist\"\n    fi\ndone";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
Instead of manually managing our build number, we can instead rely on
the number of commits on master to determine the build number. This is
an easy and cheap way to keep this number consistently incrementing.

Note that we're _not_ automatically setting the
CFBundleShortVersionString. This is intentional. In previous versions of
this technique we set that to the last created tag, but that left us in
weird spots where we didn't want the tag created yet but needed to
create a tag _just_ so that this would work properly. I think it makes
sense for that to be a manually updated thing, while we automate the
build number.
