### PR TITLE
Warn for TODO and FIXME comments

### DIFF
--- a/KICKOFF_PROJECT_NAME.xcodeproj/project.pbxproj
+++ b/KICKOFF_PROJECT_NAME.xcodeproj/project.pbxproj
@@ -376,6 +376,7 @@
 			shellScript = "if ! cmp -s \"$SRCROOT/Cartfile.resolved\" \"$SRCROOT/Carthage/Cartfile.resolved\"; then\n    >&2 echo \"error: Your dependencies are out of date. Run bin/bootstrap to update.\"\n    exit 1\nfi";
 			shellScript = "git=$(sh /etc/profile; which git)\nnumber_of_commits=$(\"$git\" rev-list master --count)\ntarget_plist=\"$TARGET_BUILD_DIR/$INFOPLIST_PATH\"\ndsym_plist=\"$DWARF_DSYM_FOLDER_PATH/$DWARF_DSYM_FILE_NAME/Contents/Info.plist\"\n\nfor plist in \"$target_plist\" \"$dsym_plist\"; do\n    if [ -f \"$plist\" ]; then\n        /usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $number_of_commits\" \"$plist\"\n    fi\ndone";
 			shellScript = "KEYWORDS=\"TODO:|FIXME:|\\?\\?\\?:|\\!\\!\\!:\"\nFILE_EXTENSIONS=\"swift|h|m|mm|c|cpp\"\nfind -E \"${SRCROOT}\" -ipath \"${SRCROOT}/Carthage\" -prune -o -ipath \"${SRCROOT}/pods\" -prune -o \\( -regex \".*\\.($FILE_EXTENSIONS)$\" \\) -print0 | xargs -0 egrep --with-filename --line-number --only-matching \"($KEYWORDS).*\\$\" | perl -p -e \"s/($KEYWORDS)/ warning: \\$1/\"\n";
+			shellScript = "KEYWORDS=\"TODO:|FIXME:|\\?\\?\\?:|\\!\\!\\!:\"\nFILE_EXTENSIONS=\"swift|h|m|mm|c|cpp\"\nfind -E \"${SRCROOT}\" -ipath \"${SRCROOT}/Carthage\" -prune -o -ipath \"${SRCROOT}/Pods\" -prune -o \\( -regex \".*\\.($FILE_EXTENSIONS)$\" \\) -print0 | xargs -0 egrep --with-filename --line-number --only-matching \"($KEYWORDS).*\\$\" | perl -p -e \"s/($KEYWORDS)/ warning: \\$1/\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/KICKOFF_PROJECT_NAME.xcodeproj/project.pbxproj
+++ b/KICKOFF_PROJECT_NAME.xcodeproj/project.pbxproj
@@ -253,6 +253,7 @@
 				417DB48342C297D9F50241D4 /* Resources */,
 				F83205341D83695500047B79 /* Embed Carthage Dependencies */,
 				F89879141D873936008BF296 /* Increment build number */,
+				F8DF34751D873F6200661DB4 /* Warn for TODO and FIXME comments */,
 			);
 			buildRules = (
 			);
@@ -358,6 +359,7 @@
 		};
 		F89879131D87375F008BF296 /* Validate Carthage dependencies */ = {
 		F89879141D873936008BF296 /* Increment build number */ = {
+		F8DF34751D873F6200661DB4 /* Warn for TODO and FIXME comments */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -366,12 +368,14 @@
 			);
 			name = "Validate Carthage dependencies";
 			name = "Increment build number";
+			name = "Warn for TODO and FIXME comments";
 			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "if ! cmp -s \"$SRCROOT/Cartfile.resolved\" \"$SRCROOT/Carthage/Cartfile.resolved\"; then\n    >&2 echo \"error: Your dependencies are out of date. Run bin/bootstrap to update.\"\n    exit 1\nfi";
 			shellScript = "git=$(sh /etc/profile; which git)\nnumber_of_commits=$(\"$git\" rev-list master --count)\ntarget_plist=\"$TARGET_BUILD_DIR/$INFOPLIST_PATH\"\ndsym_plist=\"$DWARF_DSYM_FOLDER_PATH/$DWARF_DSYM_FILE_NAME/Contents/Info.plist\"\n\nfor plist in \"$target_plist\" \"$dsym_plist\"; do\n    if [ -f \"$plist\" ]; then\n        /usr/libexec/PlistBuddy -c \"Set :CFBundleVersion $number_of_commits\" \"$plist\"\n    fi\ndone";
+			shellScript = "KEYWORDS=\"TODO:|FIXME:|\\?\\?\\?:|\\!\\!\\!:\"\nFILE_EXTENSIONS=\"swift|h|m|mm|c|cpp\"\nfind -E \"${SRCROOT}\" -ipath \"${SRCROOT}/Carthage\" -prune -o -ipath \"${SRCROOT}/pods\" -prune -o \\( -regex \".*\\.($FILE_EXTENSIONS)$\" \\) -print0 | xargs -0 egrep --with-filename --line-number --only-matching \"($KEYWORDS).*\\$\" | perl -p -e \"s/($KEYWORDS)/ warning: \\$1/\"\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
If we find a TODO or FIXME comment while building, we should generate a
warning. This will serve as an incentive to remove these comments, and
will also reduce the likelihood that we lose track of them.
