### PR TITLE
Add script to update Carthage dependencies

### DIFF
--- a/bin/update
+++ b/bin/update
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+
+carthage update --platform iOS --no-use-binaries "$@"
+cp Cartfile.resolved Carthage


### PR DESCRIPTION
`bin/update` wraps `carthage update`, providing default options. It also passes through command line arguments, so that both of these forms work:

```
# update all dependencies
bin/update

# update only the named dependencies
bin/update Argo
```
