### PR TITLE
Fix some issues with Carthage dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+{{ cookiecutter.project_name }}/Cartfile.resolved

--- a/{{ cookiecutter.project_name }}/Cartfile.private
+++ b/{{ cookiecutter.project_name }}/Cartfile.private
@@ -1,2 +1,2 @@
 github "Quick/Quick" "swift-3.0"
-github "Quick/Nimble" "swift-3.0"
+github "Quick/Nimble" "master"

--- a/{{ cookiecutter.project_name }}/Cartfile.resolved
+++ b/{{ cookiecutter.project_name }}/Cartfile.resolved
@@ -1,4 +1,0 @@
-github "Quick/Nimble" "9dc342cdffef660414d17f27aec897d0cacfffea"
-github "Quick/Quick" "8f2bc636ecfa2cc20696f62548b38d4ab943e299"
-github "thoughtbot/Runes" "e00cf681ec03a2dbf2b4cd6dd1e24d522f55474b"
-github "thoughtbot/Argo" "4b57653f7760bd3eedfd1c1fbc821bde191e603d"


### PR DESCRIPTION
The main change here is to stop tracking Cartfile.resolved, so that when installing from the template we get the latest matching versions of all dependencies.
