### PR TITLE
Update Quick and Nimble with Swift 3 support

### DIFF
--- a/{{ cookiecutter.project_name }}/Cartfile.private
+++ b/{{ cookiecutter.project_name }}/Cartfile.private
@@ -1,2 +1,2 @@
-github "Quick/Quick" "swift-3.0"
-github "Quick/Nimble" "master"
+github "Quick/Quick" ~> 0.10
+github "Quick/Nimble" ~> 5.0


### PR DESCRIPTION
The `swift-3.0` branch of Quick no longer exists which causes creating a new project to fail. Update the `Carthage.private` files to use the latest stable versions for Swift 3 support.
